### PR TITLE
Unify search

### DIFF
--- a/search-algorithms.cabal
+++ b/search-algorithms.cabal
@@ -20,6 +20,7 @@ library
   exposed-modules:     Algorithm.Search
   build-depends:       base >= 4.7 && < 5
                      , containers >= 0.5
+                     , pqueue >= 1.3
   default-language:    Haskell2010
 
 test-suite search-algorithms-test

--- a/src/Algorithm/Search.hs
+++ b/src/Algorithm/Search.hs
@@ -234,7 +234,7 @@ nextSearchState better mk_key next prunes old =
 
 
 -- | Workhorse simple search algorithm, generalized over search container
--- and combining function. The idea here is that many search algorithms are
+-- and path-choosing function. The idea here is that many search algorithms are
 -- at their core the same, with these details substituted. By writing these
 -- searches in terms of this function, we reduce the chances of errors sneaking
 -- into each separate implementation.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-7.19
+resolver: lts-8.0
 packages:
 - '.'
 extra-deps: []


### PR DESCRIPTION
Unify search algorithms to all use `generalizedSearch`. The idea is that many search algorithms are at their core the same, with only the search container and path-choosing function differing. By implementing the search algorithms in terms of a single, generalized search algorithm, we reduce the chance of errors in each individual implementation, and only the transformations to and from the generalized search algorithm need to be checked.